### PR TITLE
Fix: match file references to new names.

### DIFF
--- a/inuit-test.scss
+++ b/inuit-test.scss
@@ -68,14 +68,14 @@ a {
 
 @import "bower_components/inuit-layout/objects.layout";
 
-@import "bower_components/inuit-bare-list/objects.bare-list";
+@import "bower_components/inuit-bare-list/objects.list-bare";
 
-@import "bower_components/inuit-block-list/objects.block-list";
+@import "bower_components/inuit-block-list/objects.list-block";
 
 // Override and enable settings and features inline, just before their partial
 // is imported.
 $inuit-enable-ui-list--small:   true;
-@import "bower_components/inuit-ui-list/objects.ui-list";
+@import "bower_components/inuit-ui-list/objects.list-ui";
 
 @import "bower_components/inuit-tables/objects.tables";
 
@@ -93,7 +93,7 @@ $inuit-enable-btn--large:   true;
 $inuit-btn-border-width:    2px;
 @import "bower_components/inuit-buttons/objects.buttons";
 
-@import "bower_components/inuit-tabs/objects.tabs"; 
+@import "bower_components/inuit-tabs/objects.tabs";
 
 
 


### PR DESCRIPTION
Dev Test compiling is currently failing because file references don’t match new file names. This fixes the new "list-" convention for objects.
